### PR TITLE
fix(shimmer): fix memory leak in ShimmerView and ShimmerViewGPU. Fixes #1

### DIFF
--- a/library/src/main/java/com/ndev/android/ui/shimmer/ShimmerView.kt
+++ b/library/src/main/java/com/ndev/android/ui/shimmer/ShimmerView.kt
@@ -39,6 +39,8 @@ class ShimmerView @JvmOverloads constructor(
     private var shimmerAnimator: ValueAnimator? = null
     private var shimmerTranslate = 0f
 
+    private val startShimmerRunnable = Runnable { startShimmer() }
+
     /**
      * Called when the size of this view changes. Initializes or updates the shader used for the shimmer effect.
      *
@@ -100,9 +102,11 @@ class ShimmerView @JvmOverloads constructor(
      * Starts the shimmer animation. If the view has not been laid out yet, delays start until dimensions are known.
      */
     fun startShimmer() {
+        removeCallbacks(startShimmerRunnable)
+
         // If size is not yet established, retry after a frame
         if (width == 0 || height == 0) {
-            postDelayed({ startShimmer() }, 32)
+            postDelayed(startShimmerRunnable, 32)
             return
         }
         shimmerAnimator?.cancel()
@@ -122,6 +126,8 @@ class ShimmerView @JvmOverloads constructor(
      * Stops the shimmer animation and resets state. Removes any attached listeners.
      */
     fun stopShimmer() {
+        removeCallbacks(startShimmerRunnable)
+
         shimmerAnimator?.apply {
             removeAllUpdateListeners()
             cancel()

--- a/library/src/main/java/com/ndev/android/ui/shimmer/ShimmerViewGPU.kt
+++ b/library/src/main/java/com/ndev/android/ui/shimmer/ShimmerViewGPU.kt
@@ -46,6 +46,8 @@ class ShimmerViewGPU @JvmOverloads constructor(
     /** Path defining the union of child view bounds to mask the shimmer effect. */
     private var maskPath: Path? = null
 
+    private val startShimmerRunnable = Runnable { startShimmer() }
+
     init {
         // Enable hardware layer for better performance of the shader
         setLayerType(LAYER_TYPE_HARDWARE, shimmerPaint)
@@ -145,9 +147,11 @@ class ShimmerViewGPU @JvmOverloads constructor(
      * If the view has not been measured yet, retries after a short delay.
      */
     fun startShimmer() {
+        removeCallbacks(startShimmerRunnable)
+
         if (width == 0 || height == 0) {
             // Wait until layout is complete
-            postDelayed({ startShimmer() }, 32)
+            postDelayed(startShimmerRunnable, 32)
             return
         }
 
@@ -170,6 +174,8 @@ class ShimmerViewGPU @JvmOverloads constructor(
      * Stops the shimmer animation and invalidates the view.
      */
     fun stopShimmer() {
+        removeCallbacks(startShimmerRunnable)
+
         shimmerAnimator?.run {
             removeAllUpdateListeners()
             cancel()


### PR DESCRIPTION
- Added reusable 'startShimmerRunnable instead of anonymous lambdas
- Removed pending callbacks in 'startShimmer()' and 'stopShimmer()' to avoid leaked references
- Ensures shimmer animations are fully released when stopped